### PR TITLE
Split ClientInfoManager queue behavior to new struct

### DIFF
--- a/services/client_info/client_info_common.go
+++ b/services/client_info/client_info_common.go
@@ -27,7 +27,7 @@ var (
 `
 )
 
-func (self ClientInfoManager) QueueMessageForClient(
+func (self ClientInfoQueuer) QueueMessageForClient(
 	ctx context.Context, client_id string,
 	req *crypto_proto.VeloMessage,
 	notify bool, completion func()) error {
@@ -55,7 +55,7 @@ type ClientTask struct {
 }
 
 // Get the client's tasks and remove them from the queue.
-func (self ClientInfoManager) GetClientTasks(
+func (self ClientInfoBase) GetClientTasks(
 	ctx context.Context, client_id string) ([]*crypto_proto.VeloMessage, error) {
 
 	query := json.Format(getClientTasksQuery, client_id)
@@ -91,7 +91,7 @@ func (self ClientInfoManager) GetClientTasks(
 }
 
 // Get the client's tasks and remove them from the queue.
-func (self ClientInfoManager) PeekClientTasks(
+func (self ClientInfoBase) PeekClientTasks(
 	ctx context.Context, client_id string) ([]*crypto_proto.VeloMessage, error) {
 
 	query := json.Format(getClientTasksQuery, client_id)

--- a/services/launcher/cancel.go
+++ b/services/launcher/cancel.go
@@ -54,14 +54,14 @@ func (self *Launcher) CancelFlow(
 	}
 
 	// Queue a cancel message to the client.
-	client_manager, err := services.GetClientInfoManager(config_obj)
+	client_info_manager, err := services.GetClientInfoManager(config_obj)
 	if err != nil {
 		return nil, err
 	}
 
 	// Queue a cancellation message to the client for this flow
 	// id.
-	err = client_manager.QueueMessageForClient(ctx, client_id,
+	err = client_info_manager.QueueMessageForClient(ctx, client_id,
 		&crypto_proto.VeloMessage{
 			Cancel:    &crypto_proto.Cancel{},
 			SessionId: flow_id,

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -167,12 +167,12 @@ func (self Launcher) ScheduleArtifactCollectionFromCollectorArgs(
 	}
 
 	// Actually queue the messages to the client
-	client_manager, err := services.GetClientInfoManager(config_obj)
+	client_info_manager, err := services.GetClientInfoManager(config_obj)
 	if err != nil {
 		return "", err
 	}
 
-	client_manager.QueueMessagesForClient(ctx, client_id, tasks, true /* notify */)
+	client_info_manager.QueueMessagesForClient(ctx, client_id, tasks, true /* notify */)
 
 	return collection_context.SessionId, nil
 }


### PR DESCRIPTION
Split `ClientInfoManager` into `BaseInfo` and `Queuer`, mapped functions to appropriate struct.
This allows for easier overriding for different queuing strategies.