### PR TITLE
Handle missing labels for hunt

### DIFF
--- a/foreman/foreman.go
+++ b/foreman/foreman.go
@@ -82,7 +82,7 @@ func (self Foreman) getClientQueryForHunt(hunt *api_proto.Hunt) string {
 	must_not_condition := ""
 	if hunt.Condition != nil {
 		labels := hunt.Condition.GetLabels()
-		if labels != nil {
+		if labels != nil && len(labels.Label) > 0 {
 			extra_conditions += json.Format(
 				`{"terms": {"labels": %q}},`, labels.Label)
 		}


### PR DESCRIPTION
If a hunt is created with the `Match by label` `Include Condition`, but no labels are specified, elastic was throwing an error parsing the query. Updated the behavior to treat the hunt as if no include condition had been specified.