### PR TITLE
Add Prometheus metrics for Foreman

### DIFF
--- a/startup/foreman.go
+++ b/startup/foreman.go
@@ -6,6 +6,7 @@ import (
 	"www.velocidex.com/golang/cloudvelo/config"
 	"www.velocidex.com/golang/cloudvelo/foreman"
 	"www.velocidex.com/golang/cloudvelo/services/orgs"
+	"www.velocidex.com/golang/velociraptor/api"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/services"
 )
@@ -29,6 +30,11 @@ func StartForeman(
 
 	sm := services.NewServiceManager(ctx, config_obj.VeloConf())
 	_, err := orgs.NewOrgManager(sm.Ctx, sm.Wg, config_obj)
+	if err != nil {
+		return sm, err
+	}
+
+	err = api.StartMonitoringService(sm.Ctx, sm.Wg, config_obj.VeloConf())
 	if err != nil {
 		return sm, err
 	}


### PR DESCRIPTION
Added metrics for:
- Count of Foreman runs
- Count of orgs checked by Foreman
- Number of hunts per org
- Number of client events per org
- Number of labeled client events per org