### PR TITLE
Updated Collections Schema

### DIFF
--- a/schema/mappings/collections.json
+++ b/schema/mappings/collections.json
@@ -7,7 +7,7 @@
             "raw":                 { "type": "binary" },
             "tasks":               { "type": "binary" },
             "type":                { "type": "keyword" },
-            "timestamp":           { "type": "keyword" }
+            "timestamp":           { "type": "long" }
         }
     }
 }


### PR DESCRIPTION
Changed the schema type for the timestamp field from keyword to long so that the UI can sort based on the field.