### PR TITLE
Preserve client path when ingesting FileBuffer

### DIFF
--- a/ingestion/uploads.go
+++ b/ingestion/uploads.go
@@ -69,6 +69,8 @@ func (self Ingestor) HandleUploads(
 			Set("_Components", components).
 			Set("_Type", upload_request.Type).
 			Set("file_size", response.Size).
+			Set("_accessor", message.FileBuffer.Pathspec.Accessor).
+			Set("_client_components", message.FileBuffer.Pathspec.Components).
 			Set("uploaded_size", response.StoredSize))
 
 	return nil


### PR DESCRIPTION
This is used to create the correct path in the exported download file.