### PR TITLE
Update ingestor to use the client's install time

### DIFF
--- a/ingestion/fixtures/TestEnrollment.golden
+++ b/ingestion/fixtures/TestEnrollment.golden
@@ -6,7 +6,6 @@
  "ClientRecord": {
   "client_id": "C.1352adc54e292a23",
   "hostname": "devbox",
-  "first_seen_at": 1661391005000000000,
   "type": "main"
  }
 }

--- a/ingestion/registration.go
+++ b/ingestion/registration.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"strings"
 
-	"www.velocidex.com/golang/cloudvelo/utils"
 	actions_proto "www.velocidex.com/golang/velociraptor/actions/proto"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
 	"www.velocidex.com/golang/velociraptor/json"
@@ -13,14 +12,15 @@ import (
 )
 
 type ClientInfoUpdate struct {
-	Name         string
-	BuildTime    string
-	Labels       []string
-	Hostname     string
-	OS           string
-	Architecture string
-	Platform     string
-	MACAddresses []string
+	Name         string   `json:"Name"`
+	BuildTime    string   `json:"BuildTime"`
+	Labels       []string `json:"Labels"`
+	Hostname     string   `json:"Hostname"`
+	OS           string   `json:"OS"`
+	Architecture string   `json:"Architecture"`
+	Platform     string   `json:"Platform"`
+	MACAddresses []string `json:"MACAddresses"`
+	InstallTime  uint64   `json:"InstallTime"`
 }
 
 // Register a new client - update the client record and update it's
@@ -62,35 +62,15 @@ func (self Ingestor) HandleClientInfoUpdates(
 		if err != nil {
 			return err
 		}
-
-		// TODO: This should be an update operation but it does not
-		// happen too often (only when client is started) and we do
-		// not need to lock the record so it might be ok for now.
-		old_client_info, err := client_info_manager.Get(ctx, message.Source)
-		if err != nil {
-			old_client_info = &services.ClientInfo{actions_proto.ClientInfo{
-				Labels:       []string{},
-				MacAddresses: []string{},
-			}}
-		}
-
-		first_seen_at := old_client_info.FirstSeenAt
-		if first_seen_at == 0 {
-			first_seen_at = uint64(utils.Clock.Now().UnixNano())
-		}
-
 		err = client_info_manager.Set(ctx,
 			&services.ClientInfo{actions_proto.ClientInfo{
-				ClientId:              message.Source,
-				Hostname:              row.Hostname,
-				Fqdn:                  row.Hostname,
-				System:                row.OS,
-				Architecture:          row.Architecture,
-				MacAddresses:          row.MACAddresses,
-				FirstSeenAt:           first_seen_at,
-				Labels:                old_client_info.Labels,
-				LastHuntTimestamp:     old_client_info.LastHuntTimestamp,
-				LastEventTableVersion: old_client_info.LastEventTableVersion,
+				ClientId:     message.Source,
+				Hostname:     row.Hostname,
+				Fqdn:         row.Hostname,
+				System:       row.OS,
+				Architecture: row.Architecture,
+				MacAddresses: row.MACAddresses,
+				FirstSeenAt:  row.InstallTime,
 			}})
 		if err != nil {
 			return err

--- a/vql/uploads/uploader.go
+++ b/vql/uploads/uploader.go
@@ -391,7 +391,6 @@ func (self *VeloCloudUploader) updateServerStat(eof bool, buffer_size uint64) {
 
 	if self.index != nil {
 		message.FileBuffer.IsSparse = true
-		message.FileBuffer.Index = self.index
 	}
 
 	if !self.mtime.IsZero() {


### PR DESCRIPTION
The client reports its own install time as the first_seen_at time since we can not keep state within the ingestor.