### PR TITLE
Server artifacts receives cancellation in db

### DIFF
--- a/bin/version.go
+++ b/bin/version.go
@@ -1,0 +1,54 @@
+/*
+   Velociraptor - Dig Deeper
+   Copyright (C) 2019-2022 Rapid7 Inc.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/Velocidex/yaml/v2"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"www.velocidex.com/golang/velociraptor/config"
+)
+
+var (
+	version = app.Command("version", "Report client version.")
+)
+
+func init() {
+	command_handlers = append(command_handlers, func(command string) bool {
+		if command == version.FullCommand() {
+			res, err := yaml.Marshal(config.GetVersion())
+			if err != nil {
+				kingpin.FatalIfError(err, "Unable to encode version.")
+			}
+
+			fmt.Printf("%v", string(res))
+
+			if *verbose_flag {
+				info, ok := debug.ReadBuildInfo()
+				if ok {
+					fmt.Printf("\n\nBuild Info:\n%v\n", info)
+				}
+			}
+
+			return true
+		}
+		return false
+	})
+}

--- a/ingestion/fixtures/TestEnrollment.golden
+++ b/ingestion/fixtures/TestEnrollment.golden
@@ -6,6 +6,7 @@
  "ClientRecord": {
   "client_id": "C.1352adc54e292a23",
   "hostname": "devbox",
+  "system": "linux",
   "type": "main"
  }
 }

--- a/ingestion/registration.go
+++ b/ingestion/registration.go
@@ -12,16 +12,14 @@ import (
 )
 
 type ClientInfoUpdate struct {
-	Name          string   `json:"Name"`
-	BuildTime     string   `json:"BuildTime"`
-	Labels        []string `json:"Labels"`
-	Hostname      string   `json:"Hostname"`
-	ClientVersion string   `json:"client_version"`
-	OS            string   `json:"OS"`
-	Architecture  string   `json:"Architecture"`
-	Platform      string   `json:"Platform"`
-	MACAddresses  []string `json:"MACAddresses"`
-	InstallTime   uint64   `json:"InstallTime"`
+	ClientId      string `json:"client_id"`
+	Hostname      string `json:"hostname"`
+	Release       string `json:"release"`
+	Architecture  string `json:"architecture"`
+	ClientVersion string `json:"client_version"`
+	BuildTime     string `json:"build_time"`
+	System        string `json:"system"`
+	InstallTime   uint64 `json:"install_time"`
 }
 
 // Register a new client - update the client record and update it's
@@ -69,9 +67,9 @@ func (self Ingestor) HandleClientInfoUpdates(
 				Hostname:      row.Hostname,
 				Fqdn:          row.Hostname,
 				ClientVersion: row.ClientVersion,
-				System:        row.OS,
+				BuildTime:     row.BuildTime,
+				System:        row.System,
 				Architecture:  row.Architecture,
-				MacAddresses:  row.MACAddresses,
 				FirstSeenAt:   row.InstallTime,
 			}})
 		if err != nil {

--- a/services/launcher/cancel.go
+++ b/services/launcher/cancel.go
@@ -24,6 +24,21 @@ func (self *Launcher) CancelFlow(
 		return &api_proto.StartFlowResponse{}, nil
 	}
 
+	// Handle server collections especially via the server artifact
+	// runner.
+	if client_id == "server" {
+		server_artifacts_service, err := services.GetServerArtifactRunner(
+			config_obj)
+		if err != nil {
+			return nil, err
+		}
+
+		server_artifacts_service.Cancel(ctx, flow_id, username)
+		return &api_proto.StartFlowResponse{
+			FlowId: flow_id,
+		}, nil
+	}
+
 	// Update the collection context to set it as stopped.
 	collection_details, err := self.GetFlowDetails(
 		config_obj, client_id, flow_id)

--- a/services/launcher/launcher.go
+++ b/services/launcher/launcher.go
@@ -153,15 +153,14 @@ func (self Launcher) ScheduleArtifactCollectionFromCollectorArgs(
 		return "", err
 	}
 
-	// Run server artifacts inline.  NOTE: There is a race here
-	// between writing the collection and it becoming available for
-	// reading by the server artifact runner, so we just pass it along
-	// inline.
+	// Run server artifacts inline.
 	if client_id == "server" {
-		server_artifacts_service, err := cvelo_services.GetServerArtifactService()
+		server_artifacts_service, err := services.GetServerArtifactRunner(
+			config_obj)
 		if err != nil {
 			return "", err
 		}
+
 		err = server_artifacts_service.LaunchServerArtifact(
 			config_obj, session_id, task.FlowRequest, collection_context)
 		return collection_context.SessionId, err

--- a/services/orgs/delete.go
+++ b/services/orgs/delete.go
@@ -4,11 +4,22 @@ import (
 	"context"
 	"errors"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"www.velocidex.com/golang/cloudvelo/schema"
 	cvelo_services "www.velocidex.com/golang/cloudvelo/services"
+	"www.velocidex.com/golang/velociraptor/logging"
 	"www.velocidex.com/golang/velociraptor/services"
 	"www.velocidex.com/golang/velociraptor/services/orgs"
 	"www.velocidex.com/golang/velociraptor/utils"
+)
+
+var (
+	deleteOrgCounter = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "velociraptor_delete_org_count",
+			Help: "Count of organizations deleted from the Velociraptor system.",
+		})
 )
 
 // Remove the org and all its data.
@@ -17,6 +28,11 @@ func (self *OrgManager) DeleteOrg(
 
 	if utils.IsRootOrg(org_id) {
 		return errors.New("Can not remove root org.")
+	}
+
+	logger := logging.GetLogger(self.config_obj, &logging.Audit)
+	if logger != nil {
+		logger.Info("Deleted organization: %v", org_id)
 	}
 
 	err := orgs.RemoveOrgFromUsers(ctx, org_id)
@@ -36,6 +52,8 @@ func (self *OrgManager) DeleteOrg(
 	delete(self.orgs, org_id)
 	delete(self.org_id_by_nonce, org_id)
 	self.mu.Unlock()
+
+	deleteOrgCounter.Inc()
 
 	// Drop all the org's indexes
 	return schema.Delete(self.ctx, self.config_obj,

--- a/services/orgs/lazy.go
+++ b/services/orgs/lazy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 
+	"www.velocidex.com/golang/cloudvelo/config"
 	"www.velocidex.com/golang/cloudvelo/services/acl_manager"
 	"www.velocidex.com/golang/cloudvelo/services/client_info"
 	"www.velocidex.com/golang/cloudvelo/services/client_monitoring"
@@ -15,6 +16,7 @@ import (
 	"www.velocidex.com/golang/cloudvelo/services/launcher"
 	"www.velocidex.com/golang/cloudvelo/services/notebook"
 	"www.velocidex.com/golang/cloudvelo/services/notifier"
+	"www.velocidex.com/golang/cloudvelo/services/server_artifacts"
 	"www.velocidex.com/golang/cloudvelo/services/vfs_service"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	"www.velocidex.com/golang/velociraptor/services"
@@ -26,9 +28,10 @@ import (
 type LazyServiceContainer struct {
 	mu sync.Mutex
 
-	ctx        context.Context
-	wg         *sync.WaitGroup
-	config_obj *config_proto.Config
+	ctx          context.Context
+	wg           *sync.WaitGroup
+	config_obj   *config_proto.Config
+	cloud_config *config.ElasticConfiguration
 
 	// Elastic is too slow to serve the repository manager directly so
 	// we cache it here.
@@ -50,6 +53,10 @@ func (self *LazyServiceContainer) Notifier() (services.Notifier, error) {
 
 func (self *LazyServiceContainer) ServerEventManager() (services.ServerEventManager, error) {
 	return nil, errors.New("LazyServiceContainer.ServerEventManager is Not implemented")
+}
+
+func (self *LazyServiceContainer) ServerArtifactRunner() (services.ServerArtifactRunner, error) {
+	return server_artifacts.NewServerArtifactService(self.ctx, self.config_obj, self.cloud_config, self.wg)
 }
 
 func (self *LazyServiceContainer) ClientEventManager() (services.ClientEventTable, error) {

--- a/services/orgs/services.go
+++ b/services/orgs/services.go
@@ -52,9 +52,10 @@ func (self *OrgManager) makeNewOrgContext(org_id, name, nonce string) (*OrgConte
 
 	org_config := self.makeNewConfigObj(record)
 	service_manager := &LazyServiceContainer{
-		wg:         self.wg,
-		ctx:        self.ctx,
-		config_obj: org_config,
+		wg:           self.wg,
+		ctx:          self.ctx,
+		config_obj:   org_config,
+		cloud_config: self.cloud_config,
 	}
 
 	org_context := &OrgContext{

--- a/services/server_artifacts/server_artifacts.go
+++ b/services/server_artifacts/server_artifacts.go
@@ -2,19 +2,24 @@ package server_artifacts
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
+	"time"
 
 	"www.velocidex.com/golang/cloudvelo/config"
-	"www.velocidex.com/golang/cloudvelo/services"
+	"www.velocidex.com/golang/cloudvelo/schema/api"
+	cvelo_services "www.velocidex.com/golang/cloudvelo/services"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
 	crypto_proto "www.velocidex.com/golang/velociraptor/crypto/proto"
 	flows_proto "www.velocidex.com/golang/velociraptor/flows/proto"
+	"www.velocidex.com/golang/velociraptor/services"
+	"www.velocidex.com/golang/velociraptor/utils"
 
 	"www.velocidex.com/golang/velociraptor/services/server_artifacts"
 )
 
-type ServerArtifactsRunner struct {
-	*server_artifacts.ServerArtifactsRunner
+type ServerArtifactRunner struct {
+	*server_artifacts.ServerArtifactRunner
 
 	ctx          context.Context
 	wg           *sync.WaitGroup
@@ -22,12 +27,24 @@ type ServerArtifactsRunner struct {
 	cloud_config *config.ElasticConfiguration
 }
 
-func (self *ServerArtifactsRunner) CloudConfig() *config.ElasticConfiguration {
+func (self *ServerArtifactRunner) CloudConfig() *config.ElasticConfiguration {
 	return self.cloud_config
 }
 
+// Just leave a message for the main runner that the collection should
+// be cancelled.
+func (self *ServerArtifactRunner) Cancel(
+	ctx context.Context, flow_id, principal string) {
+	cvelo_services.SetElasticIndex(
+		self.ctx, self.config_obj.OrgId, "collections",
+		flow_id+"_cancel", &api.ArtifactCollectorRecord{
+			ClientId:  principal,
+			SessionId: flow_id,
+		})
+}
+
 // Run the specified server collection in the background
-func (self *ServerArtifactsRunner) LaunchServerArtifact(
+func (self *ServerArtifactRunner) LaunchServerArtifact(
 	config_obj *config_proto.Config,
 	session_id string,
 	req *crypto_proto.FlowRequest,
@@ -37,19 +54,45 @@ func (self *ServerArtifactsRunner) LaunchServerArtifact(
 		return nil
 	}
 
-	sub_ctx, cancel := context.WithCancel(self.ctx)
 	collection_context_manager, err := server_artifacts.NewCollectionContextManager(
-		sub_ctx, self.wg, config_obj, &crypto_proto.VeloMessage{
-			Source:      "server",
-			SessionId:   session_id,
-			FlowRequest: req,
-		}, collection_context)
+		context.Background(), self.wg, config_obj, req, collection_context)
 	if err != nil {
 		return err
 	}
 
+	sub_ctx, cancel := context.WithCancel(self.ctx)
+
 	// Write the collection to storage periodically.
 	collection_context_manager.StartRefresh(self.wg)
+
+	// Check for cancellation messages.
+	self.wg.Add(1)
+	go func() {
+		defer self.wg.Done()
+
+		for {
+			select {
+			case <-sub_ctx.Done():
+				return
+
+			case <-utils.GetTime().After(10 * time.Second):
+				// If this record appears, we immediately cancel.
+				serialized, err := cvelo_services.GetElasticRecord(sub_ctx,
+					self.config_obj.OrgId, "collections", session_id+"_cancel")
+				if err == nil {
+					record := &api.ArtifactCollectorRecord{}
+					err = json.Unmarshal(serialized, record)
+					if err == nil {
+						// Call our base class to cancel the
+						// collection.
+						self.ServerArtifactRunner.Cancel(sub_ctx,
+							session_id, record.ClientId)
+					}
+					return
+				}
+			}
+		}
+	}()
 
 	self.wg.Add(1)
 	go func() {
@@ -68,15 +111,14 @@ func NewServerArtifactService(
 	ctx context.Context,
 	config_obj *config_proto.Config,
 	cloud_config *config.ElasticConfiguration,
-	wg *sync.WaitGroup) services.ServerArtifactsService {
+	wg *sync.WaitGroup) (services.ServerArtifactRunner, error) {
 
-	// Start a server_artifacts runner without checking the tasks
-	// queues.
-	return &ServerArtifactsRunner{
-		ServerArtifactsRunner: server_artifacts.NewServerArtifactRunner(
+	return &ServerArtifactRunner{
+		ServerArtifactRunner: server_artifacts.NewServerArtifactRunner(
 			ctx, config_obj, wg),
 		ctx:          ctx,
 		wg:           wg,
+		config_obj:   config_obj,
 		cloud_config: cloud_config,
-	}
+	}, nil
 }

--- a/services/users/delete.go
+++ b/services/users/delete.go
@@ -4,10 +4,29 @@ import (
 	"context"
 	"errors"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	config_proto "www.velocidex.com/golang/velociraptor/config/proto"
+	"www.velocidex.com/golang/velociraptor/logging"
+)
+
+var (
+	deleteUserCounter = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "velociraptor_delete_user_count",
+			Help: "Count of users deleted from the Velociraptor system.",
+		})
 )
 
 func (self *UserManager) DeleteUser(
 	ctx context.Context, org_config_obj *config_proto.Config, username string) error {
+
+	logger := logging.GetLogger(&self.config_obj.Config, &logging.Audit)
+	if logger != nil {
+		logger.Info("Deleted user: %v", username)
+	}
+
+	deleteUserCounter.Inc()
+
 	return errors.New("UserManager.DeleteUser not implemented")
 }

--- a/startup/gui.go
+++ b/startup/gui.go
@@ -4,10 +4,8 @@ import (
 	"context"
 
 	"www.velocidex.com/golang/cloudvelo/config"
-	cvelo_services "www.velocidex.com/golang/cloudvelo/services"
 	"www.velocidex.com/golang/cloudvelo/services/orgs"
 	"www.velocidex.com/golang/cloudvelo/services/sanity"
-	"www.velocidex.com/golang/cloudvelo/services/server_artifacts"
 	"www.velocidex.com/golang/velociraptor/accessors"
 	file_store_accessor "www.velocidex.com/golang/velociraptor/accessors/file_store"
 	"www.velocidex.com/golang/velociraptor/api"
@@ -52,11 +50,6 @@ func StartGUIServices(
 	if err != nil {
 		return sm, err
 	}
-
-	cvelo_services.RegisterServerArtifactsService(
-		server_artifacts.NewServerArtifactService(
-			sm.Ctx, config_obj.VeloConf(),
-			&config_obj.Cloud, sm.Wg))
 
 	// Start the listening server
 	server_builder, err := api.NewServerBuilder(

--- a/vql/uploads/api.go
+++ b/vql/uploads/api.go
@@ -22,6 +22,10 @@ type CloudUploader interface {
 		size int64, // Expected size.
 		uploader_type string) (CloudUploader, error)
 
+	// Upload the buffer as a single part upload. This is used for
+	// files that are smaller than BUFF_SIZE.
+	PutWhole(buf []byte) error
+
 	// Upload the buffer as a multipart upload.  NOTE: This will be
 	// called with minimum 5mb buffers for each part except for the
 	// final part.

--- a/vql/uploads/uploader.go
+++ b/vql/uploads/uploader.go
@@ -310,6 +310,10 @@ func (self *VeloCloudUploader) Start(ctx context.Context) error {
 	return nil
 }
 
+func (self *VeloCloudUploader) PutWhole(buf []byte) error {
+	return self.Put(buf)
+}
+
 func (self *VeloCloudUploader) Put(buf []byte) error {
 	self.md5_sum.Write(buf)
 	self.sha_sum.Write(buf)

--- a/vql/uploads/vql.go
+++ b/vql/uploads/vql.go
@@ -182,17 +182,13 @@ func (self UploadFunction) Upload(
 		}, nil
 	}
 
-	err = buffer.Flush()
+	err = buffer.Close()
 	if err != nil {
 		scope.Log("ERROR: Finalizing %v: %v", dest, err)
 		return &uploads.UploadResponse{
 			Error: err.Error(),
 		}, nil
 	}
-
-	// If we get here it all went well - commit the result.
-	uploader.Commit()
-	uploader.Close()
 
 	return uploader.GetVQLResponse(), nil
 }


### PR DESCRIPTION
In a distributed server the db is the most reliable way to issue a cancellation message to the artifact runner.

This change allows the server artifact runner to be stateless.