### PR TITLE
Merge ClientId from Elastic record

### DIFF
--- a/foreman/plan.go
+++ b/foreman/plan.go
@@ -100,7 +100,6 @@ func (self *Plan) scheduleRequestOnClients(
 
 		return multi_launcher.ScheduleVQLCollectorArgsOnMultipleClients(
 			ctx, org_config_obj, request_copy, clients)
-
 	}
 
 	// Otherwise just schedule clients one at the time.

--- a/schema/api/collections.go
+++ b/schema/api/collections.go
@@ -28,6 +28,13 @@ func (self *ArtifactCollectorRecord) ToProto() (
 		return nil, err
 	}
 
+	// For mass duplicated flows, client id inside the protobuf is not
+	// set (since it is the same for all requests). We therefore
+	// override it from the Elastic record.
+	if result.ClientId == "" {
+		result.ClientId = self.ClientId
+	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
For collection_context written as part of the multi scheduling the client id is blank because the same context is copied to all clients. In this case we store the client id in the Elastic record itself so we can fill in a valid client id.