### PR TITLE
Merge collections records more intelligently

### DIFF
--- a/ingestion/collections.go
+++ b/ingestion/collections.go
@@ -36,7 +36,8 @@ func (self Ingestor) HandleResponses(
 	case "System.VFS.ListDirectory/Stats":
 		_ = self.HandleSystemVfsListDirectory(ctx, config_obj, message)
 
-	case "Generic.Client.Info/BasicInformation":
+	case "Generic.Client.Info/BasicInformation",
+		"Custom.Generic.Client.Info/BasicInformation":
 		_ = self.HandleInterrogation(ctx, config_obj, message)
 
 	case "System.VFS.DownloadFile":


### PR DESCRIPTION
There are two records which contain collection QueryStats:
- The progress QueryStats occur during progress of the collection
- The completed QueryStats are set when the collection is completed.

When we read the collection record we need to merge these records together. Previously we merged these records blindly but this leads to cases where the progress stats override the completion stats - leaving the collection is an uncompleted state.

This PR ensures that completed stats always remain and override in progress stats.