### PR TITLE
Update search.go

### DIFF
--- a/services/indexing/search.go
+++ b/services/indexing/search.go
@@ -88,7 +88,7 @@ func (self *Indexer) searchRecents(
 }
 
 const (
-	allClientsQuery    = `{"range": {"first_seen_at": {"gt": 0}}}`
+	allClientsQuery    = `{"range": {"first_seen_at": {"gte": 0}}}`
 	recentClientsQuery = `{
    "range": {
      "ping": {"gt": %q}


### PR DESCRIPTION
Updated to use greater than or equal to on all query as clients are coming through without an installed time and we are defaulting their first_seen_time to 0, so this will allow them to still be viewed in the client list.