### PR TITLE
Bug-Fix: Deduplicate VFS Downloads Array

### DIFF
--- a/services/vfs_service/directory.go
+++ b/services/vfs_service/directory.go
@@ -188,7 +188,7 @@ func (self *VFSService) readDirectoryWithDownloads(
 	if err != nil {
 		return nil, nil, err
 	}
-
+	downloads_map := make(map[string]int)
 	for _, hit := range hits {
 		record := &VFSRecord{}
 		err = json.Unmarshal(hit, record)
@@ -209,8 +209,16 @@ func (self *VFSService) readDirectoryWithDownloads(
 			if err != nil {
 				continue
 			}
+			filename := download_record.Components[len(download_record.Components)-1]
+			if val, ok := downloads_map[filename]; ok {
+				if download_record.Mtime > downloads[val].Mtime {
+					downloads[val] = download_record
+				}
+			} else {
+				downloads_map[filename] = len(downloads)
+				downloads = append(downloads, download_record)
+			}
 
-			downloads = append(downloads, download_record)
 			if download_record.Mtime > stat.DownloadVersion {
 				stat.DownloadVersion = download_record.Mtime
 			}

--- a/services/vfs_service/directory.go
+++ b/services/vfs_service/directory.go
@@ -188,7 +188,7 @@ func (self *VFSService) readDirectoryWithDownloads(
 	if err != nil {
 		return nil, nil, err
 	}
-	downloads_map := make(map[string]int)
+	downloads_index := make(map[string]int)
 	for _, hit := range hits {
 		record := &VFSRecord{}
 		err = json.Unmarshal(hit, record)
@@ -210,12 +210,14 @@ func (self *VFSService) readDirectoryWithDownloads(
 				continue
 			}
 			filename := download_record.Components[len(download_record.Components)-1]
-			if val, ok := downloads_map[filename]; ok {
-				if download_record.Mtime > downloads[val].Mtime {
-					downloads[val] = download_record
+			download_idx, ok := downloads_index[filename]
+
+			if ok {
+				if download_record.Mtime > downloads[download_idx].Mtime {
+					downloads[download_idx] = download_record
 				}
 			} else {
-				downloads_map[filename] = len(downloads)
+				downloads_index[filename] = len(downloads)
 				downloads = append(downloads, download_record)
 			}
 


### PR DESCRIPTION
# Discription
I added a check only to take the most recent download records when assembling the download list.

# Testing
Manually tested locally.
Testcases:
- [x] Downloading a single file via VFS
- [x] Downloading multiple files simultaneously
- [x] Downloading 2 files across two beacon periods to make sure they both updated the UI separately when complete
- [x] Re-collected single file
- [x] Re-collected multiple files simultaneously
