### PR TITLE
fix: Remove unused doc_id from vfs side query

### DIFF
--- a/services/vfs_service/assembler.go
+++ b/services/vfs_service/assembler.go
@@ -34,8 +34,6 @@ const (
         "bool": {
             "must": [
                 {
-                    "match": {"doc_id": %q}
-                }, {
                     "match": {"id": %q}
                 }, {
                     "match": {"doc_type": "vfs"}


### PR DESCRIPTION
with the elastic indexes being consolidated it looks like this field is no longer required.

example data
```
"hits": [
      {
        "_index": ".ds-abcd-efgh-1234_results-000001",
        "_id": "jH9xkowBkvR72Sl_q5vq",
        "_score": null,
        "_source": {
          "id": "242b71e773cb829dfc79893584f40aba1e4b320d",
          "client_id": "89c8f669ff934c41b0b1cec26e4c4d64",
          "components": [
            "89c8f669ff934c41b0b1cec26e4c4d64",
            "auto"
          ],
          "doc_type": "vfs",
          "data": """{"client_id":"89c8f669ff934c41b0b1cec26e4c4d64","flow_id":"F.CM2RTCBLHKN08","timestamp":1703263972324000000,"total_rows":24,"start_idx":0,"end_idx":24,"artifact":"System.VFS.ListDirectory/Listing"}""",
          "timestamp": 1703263972324000000
        },
        "sort": [
          1703263972324000000
        ]
      }
    ]
```