### PR TITLE
ENDPOINT-7506: Fix for duplicate clients appearing in search

### DIFF
--- a/services/indexing/search.go
+++ b/services/indexing/search.go
@@ -423,7 +423,7 @@ func (self *Indexer) searchVerbs(ctx context.Context,
 	}
 
 	// Maybe a label
-	if uint64(len(items)) < in.Limit {
+	if uint64(len(items)) < in.Limit && total == 0 {
 		res, total, err = self.searchClientsByLabel(
 			ctx, config_obj, "label", in.Query, in, in.Limit)
 		if err == nil {


### PR DESCRIPTION
## Description
When you filter for online clients and then search ( for a hostname for example ), duplicate clients are shown. I updated the searchVerbs function so that it will only check for a label with the search term after zero hostnames with that search term are returned as this was causing the duplication. 