### PR TITLE
fix:(ENDPOINT-8668): Use `doc_id` to only directory listings

### DIFF
--- a/services/vfs_service/assembler.go
+++ b/services/vfs_service/assembler.go
@@ -34,7 +34,7 @@ const (
         "bool": {
             "must": [
                 {
-                    "match": {"id": %q}
+                    "match": {"doc_id": %q}
                 }, {
                     "match": {"doc_type": "vfs"}
                 }
@@ -71,7 +71,7 @@ const (
     "sort": [
       {
         "timestamp": {
-          "order": "asc"
+          "order": "desc"
         }
       }
     ],

--- a/services/vfs_service/assembler.go
+++ b/services/vfs_service/assembler.go
@@ -34,6 +34,8 @@ const (
         "bool": {
             "must": [
                 {
+                    "match": {"id": %q}
+                }, {
                     "match": {"doc_id": %q}
                 }, {
                     "match": {"doc_type": "vfs"}
@@ -71,7 +73,7 @@ const (
     "sort": [
       {
         "timestamp": {
-          "order": "desc"
+          "order": "asc"
         }
       }
     ],


### PR DESCRIPTION
`id` is currently used to retrieve both directory listings and download results. `doc_id` is prepended with `download_` for download listings and will be excluded from the results.

This PR requires that https://github.com/rapid7/velociraptor-ingestion/pull/382 is available.

Also ensures that the most recent result is returned from VFS directory listings.