### PR TITLE
NO-ENDPOINT: Updated to get all orgs

### DIFF
--- a/services/orgs/orgs.go
+++ b/services/orgs/orgs.go
@@ -145,7 +145,7 @@ func (self *OrgManager) makeNewConfigObj(
 func (self *OrgManager) Scan() error {
 	hits, _, err := cvelo_services.QueryElasticRaw(
 		self.ctx, services.ROOT_ORG_ID,
-		"orgs", `{"query": {"match_all" : {}}}`)
+		"orgs", `{"query": {"match_all" : {}}, "size": 10000}`)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This function was only returning the first 10 orgs causing the foreman to miss other orgs when monitoring for hunts to dispatch. This will allow the foreman to see all available orgs for monitoring.