### PR TITLE
Revert "fix: Remove unused doc_id from vfs side query (#124)"

### DIFF
--- a/services/vfs_service/assembler.go
+++ b/services/vfs_service/assembler.go
@@ -34,6 +34,8 @@ const (
         "bool": {
             "must": [
                 {
+                    "match": {"doc_id": %q}
+                }, {
                     "match": {"id": %q}
                 }, {
                     "match": {"doc_type": "vfs"}


### PR DESCRIPTION
This reverts commit 9eb08b55f315fe61f2325b8c5b86e121821d02c6.

This commit breaks VFS queries as the doc_id field is really still used.