### PR TITLE
NO-ENDPOINT: Updated OpenSearch Schema

### DIFF
--- a/schema/policies/rollover_strategy.json
+++ b/schema/policies/rollover_strategy.json
@@ -31,8 +31,8 @@
       }
     ],
     "ism_template": {
-      "index_patterns": ["*_results*"],
-      "priority": 101
+      "index_patterns": ["*_transient*"],
+      "priority": 300
     }
   }
 }

--- a/schema/templates/error.json
+++ b/schema/templates/error.json
@@ -1,0 +1,22 @@
+{
+  "index_patterns": [
+    "*_error"
+  ],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0
+    },
+    "mappings": {
+      "dynamic": false,
+      "properties": {
+        "client_id": {
+          "type": "keyword"
+        },
+        "data": {
+          "type": "text"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Updated OpenSearch schema to correct data stream name for the new format and added schema definition of error indexes. Without the error index definition, OpenSearch defaults to using 10 shards for the error index which is very wasteful, with 5 primary and 5 replicas.