### PR TITLE
Bugfix: LoadCollectionContext only merged some items.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ debug_pool_client:
 gui:
 	$(BINARY) $(CONFIG_ARGS) gui -v --debug
 
+dump:
+	$(BINARY) $(CONFIG_ARGS) elastic dump -v
+
 debug_gui:
 	$(DLV) $(CONFIG_ARGS) gui -v --debug
 

--- a/bin/elastic.go
+++ b/bin/elastic.go
@@ -3,8 +3,12 @@ package main
 import (
 	"fmt"
 
+	"github.com/Velocidex/ordereddict"
 	"www.velocidex.com/golang/cloudvelo/schema"
 	"www.velocidex.com/golang/cloudvelo/services"
+	"www.velocidex.com/golang/velociraptor/json"
+	vql_subsystem "www.velocidex.com/golang/velociraptor/vql"
+	"www.velocidex.com/golang/vfilter"
 )
 
 var (
@@ -14,7 +18,7 @@ var (
 	elastic_command_reset = elastic_command.Command(
 		"reset", "Drop all the indexes and recreate them")
 
-	elastic_command_reset_org_id = elastic_command.Flag(
+	elastic_command_reset_org_id = elastic_command_reset.Flag(
 		"org_id", "An OrgID to initialize").String()
 
 	elastic_command_recreate = elastic_command.Flag(
@@ -22,6 +26,19 @@ var (
 
 	elastic_command_reset_filter = elastic_command_reset.Arg(
 		"index_filter", "If specified only re-create these indexes").String()
+
+	elastic_command_dump = elastic_command.Command(
+		"dump", "Dump the entire index - probably only useful for debugging")
+
+	elastic_command_dump_index = elastic_command_dump.Flag(
+		"index", "Name of index to dump").Default("transient").String()
+
+	elastic_command_dump_org_id = elastic_command_dump.Flag(
+		"org_id", "An OrgID to initialize").String()
+
+	elastic_command_dump_filter = elastic_command_dump.Flag(
+		"filter", "A VQL Lambda to filter rows by e.g. x=> x.type =~ 'results'").
+		Default("x=>TRUE").String()
 )
 
 func doResetElastic() error {
@@ -56,12 +73,68 @@ func doResetElastic() error {
 		*elastic_command_reset_filter)
 }
 
+func doDumpElastic() error {
+	config_obj, err := loadConfig(makeDefaultConfigLoader())
+	if err != nil {
+		return fmt.Errorf("loading config file: %w", err)
+	}
+
+	ctx, cancel := install_sig_handler()
+	defer cancel()
+
+	err = services.StartElasticSearchService(ctx, config_obj)
+	if err != nil {
+		return err
+	}
+
+	lambda, err := vfilter.ParseLambda(*elastic_command_dump_filter)
+	if err != nil {
+		return err
+	}
+	scope := vql_subsystem.MakeScope()
+
+	rows, err := services.QueryChan(ctx, config_obj.VeloConf(), 1000,
+		*elastic_command_dump_org_id,
+		*elastic_command_dump_index,
+		`{"query": {"match_all" : {}}}`, "_id")
+	if err != nil {
+		return err
+	}
+
+	count := 0
+	for raw_message := range rows {
+		item := ordereddict.NewDict()
+		err := json.Unmarshal(raw_message, &item)
+		if err != nil {
+			continue
+		}
+
+		filter := lambda.Reduce(ctx, scope, []vfilter.Any{item})
+		if !scope.Bool(filter) {
+			continue
+		}
+
+		item.Set("Count", count)
+		count++
+
+		fmt.Println(string(json.MustMarshalIndent(item)))
+	}
+
+	return nil
+}
+
 func init() {
 	command_handlers = append(command_handlers, func(command string) bool {
 		if command == elastic_command_reset.FullCommand() {
 			FatalIfError(elastic_command_reset, doResetElastic)
 			return true
 		}
+
+		if command == elastic_command_dump.FullCommand() {
+			FatalIfError(elastic_command_dump, doDumpElastic)
+			return true
+		}
+
 		return false
 	})
 }

--- a/bin/elastic.go
+++ b/bin/elastic.go
@@ -39,6 +39,10 @@ var (
 	elastic_command_dump_filter = elastic_command_dump.Flag(
 		"filter", "A VQL Lambda to filter rows by e.g. x=> x.type =~ 'results'").
 		Default("x=>TRUE").String()
+
+	elastic_command_dump_sort = elastic_command_dump.Flag(
+		"sort", "A field to sort by (default 'timestamp')").
+		Default("timestamp").String()
 )
 
 func doResetElastic() error {
@@ -96,7 +100,7 @@ func doDumpElastic() error {
 	rows, err := services.QueryChan(ctx, config_obj.VeloConf(), 1000,
 		*elastic_command_dump_org_id,
 		*elastic_command_dump_index,
-		`{"query": {"match_all" : {}}}`, "_id")
+		`{"query": {"match_all" : {}}}`, *elastic_command_dump_sort)
 	if err != nil {
 		return err
 	}

--- a/services/elasticsearch.go
+++ b/services/elasticsearch.go
@@ -663,6 +663,9 @@ func QueryChan(
 
 					search_after, pres = row.Get(sort_field)
 					if !pres {
+						logger := logging.GetLogger(config_obj,
+							&logging.FrontendComponent)
+						logger.Error("QueryChan: Row does not contain sorting column %v", sort_field)
 						return
 					}
 				}
@@ -820,12 +823,7 @@ func QueryElasticRaw(
 
 	var results []json.RawMessage
 	for _, hit := range parsed.Hits.Hits {
-		// Append the id to the end
-		source := hit.Source
-		source = source[:len(source)-1]
-		source = append(source, []byte(json.Format(`, "_id":%q}`, hit.Id))...)
-
-		results = append(results, source)
+		results = append(results, hit.Source)
 	}
 
 	return results, parsed.Hits.Total.Value, nil

--- a/services/elasticsearch.go
+++ b/services/elasticsearch.go
@@ -820,7 +820,12 @@ func QueryElasticRaw(
 
 	var results []json.RawMessage
 	for _, hit := range parsed.Hits.Hits {
-		results = append(results, hit.Source)
+		// Append the id to the end
+		source := hit.Source
+		source = source[:len(source)-1]
+		source = append(source, []byte(json.Format(`, "_id":%q}`, hit.Id))...)
+
+		results = append(results, source)
 	}
 
 	return results, parsed.Hits.Total.Value, nil


### PR DESCRIPTION
Since migration to the datastream indexes, collection context is updated many times through the collection lifetime. To reconstruct the most up to date object we need to scan all the rows (since they are no longer overwritten).

This PR fixes a bug where only a few collection documents were fetches so for collections which dont return results for a while (but still send progress messages) the GUI was unable to see the latest state of the object and did not show any results.