### PR TITLE
Total client count 10k limit

### DIFF
--- a/services/elasticsearch.go
+++ b/services/elasticsearch.go
@@ -884,7 +884,7 @@ func QueryCountAPI(
 	ctx context.Context,
 	org_id, index, query string) (total int, err error) {
 
-	defer Instrument("QueryElasticIds")()
+	defer Instrument("QueryCountAPI")()
 	es, err := GetElasticClient()
 	if err != nil {
 		return 0, err

--- a/services/indexing/search.go
+++ b/services/indexing/search.go
@@ -154,7 +154,26 @@ const (
  "size": 0
 }
 `
-	hostnameExistsQuery = `{"query": {"exists": {"field": "hostname"}}}`
+	getAllClientDocsQuery = `
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "exists": {
+            "field": "hostname"
+          }
+        },
+        {
+          "match": {
+            "doc_type": "clients"
+          }
+        }
+      ]
+    }
+  }
+}
+`
 )
 
 func (self *Indexer) getAllClients(
@@ -175,7 +194,7 @@ func (self *Indexer) getAllClients(
 	clients, _, err := self.searchWithTerms(ctx, config_obj,
 		in.Filter, terms, in.Offset, in.Limit)
 	total, err := cvelo_services.QueryCountAPI(
-		ctx, config_obj.OrgId, "persisted", hostnameExistsQuery)
+		ctx, config_obj.OrgId, "persisted", getAllClientDocsQuery)
 	return clients, total, err
 }
 

--- a/services/indexing/search.go
+++ b/services/indexing/search.go
@@ -154,6 +154,7 @@ const (
  "size": 0
 }
 `
+	hostnameExistsQuery = `{"query": {"exists": {"field": "hostname"}}}`
 )
 
 func (self *Indexer) getAllClients(
@@ -174,7 +175,7 @@ func (self *Indexer) getAllClients(
 	clients, _, err := self.searchWithTerms(ctx, config_obj,
 		in.Filter, terms, in.Offset, in.Limit)
 	total, err := cvelo_services.QueryCountAPI(
-		ctx, config_obj.OrgId, "persisted", allClientsQuery)
+		ctx, config_obj.OrgId, "persisted", hostnameExistsQuery)
 	return clients, total, err
 }
 

--- a/services/indexing/search.go
+++ b/services/indexing/search.go
@@ -171,8 +171,11 @@ func (self *Indexer) getAllClients(
 	}
 
 	terms := []string{allClientsQuery}
-	return self.searchWithTerms(ctx, config_obj,
+	clients, _, err := self.searchWithTerms(ctx, config_obj,
 		in.Filter, terms, in.Offset, in.Limit)
+	total, err := cvelo_services.QueryCountAPI(
+		ctx, config_obj.OrgId, "persisted", allClientsQuery)
+	return clients, total, err
 }
 
 const (


### PR DESCRIPTION
# Description
The total clients displayed in the clients search is limited by the maximum number of hits returned by OpenSearch, 
this value should instead reflect the actual total number of documents in the index