### PR TITLE
Allow For Secondary OpenSearch Cluster

### DIFF
--- a/config/api.go
+++ b/config/api.go
@@ -23,6 +23,7 @@ type ElasticConfiguration struct {
 	Password           string   `json:"password"`
 	APIKey             string   `json:"api_key"`
 	Addresses          []string `json:"addresses"`
+	SecondaryAddresses []string `json:"secondary_addresses"`
 	CloudID            string   `json:"cloud_id"`
 	DisableSSLSecurity bool     `json:"disable_ssl_security"`
 	RootCerts          string   `json:"root_cert"`

--- a/schema/initialize.go
+++ b/schema/initialize.go
@@ -32,7 +32,7 @@ var fs embed.FS
 func Delete(ctx context.Context,
 	config_obj *config_proto.Config, org_id, filter string) error {
 
-	client, err := services.GetElasticClient()
+	client, err := services.GetElasticClient(org_id)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Extended the Elastic configuration to allow for there to be a secondary OpenSearch cluster to handle overflow or segregated orgs.