### PR TITLE
Allow for Secondary OpenSearch Cluster

### DIFF
--- a/Docker/docker-compose.yaml
+++ b/Docker/docker-compose.yaml
@@ -6,8 +6,6 @@
 # * The "base" profile brings up only opensearch and localstack so you
 #   can start various Velociraptor services manually (See Makefile in
 #   top level).
-
-version: '3.9'
 services:
   opensearch:
     profiles:

--- a/bin/elastic.go
+++ b/bin/elastic.go
@@ -60,7 +60,7 @@ func doResetElastic() error {
 	}
 
 	// Make sure the database is properly configured
-	err = schema.InstallIndexTemplates(ctx, config_obj.VeloConf())
+	err = schema.InstallIndexTemplates(ctx, config_obj)
 	if err != nil {
 		return err
 	}

--- a/config/api.go
+++ b/config/api.go
@@ -23,6 +23,8 @@ type ElasticConfiguration struct {
 	Password           string   `json:"password"`
 	APIKey             string   `json:"api_key"`
 	Addresses          []string `json:"addresses"`
+	SecondaryAddresses []string `json:"secondary_addresses"`
+	PrimaryOrgs        []string `json:"primary_orgs"`
 	CloudID            string   `json:"cloud_id"`
 	DisableSSLSecurity bool     `json:"disable_ssl_security"`
 	RootCerts          string   `json:"root_cert"`

--- a/ingestion/ingestor.go
+++ b/ingestion/ingestor.go
@@ -118,7 +118,7 @@ func NewIngestor(
 	config_obj *config.Config,
 	crypto_manager *server.ServerCryptoManager) (*Ingestor, error) {
 
-	client, err := cvelo_services.GetElasticClient()
+	client, err := cvelo_services.GetElasticClientByType("primary")
 	if err != nil {
 		return nil, err
 	}

--- a/ingestion/ingestor.go
+++ b/ingestion/ingestor.go
@@ -118,7 +118,8 @@ func NewIngestor(
 	config_obj *config.Config,
 	crypto_manager *server.ServerCryptoManager) (*Ingestor, error) {
 
-	client, err := cvelo_services.GetElasticClientByType("primary")
+	client, err := cvelo_services.GetElasticClientByType(
+		cvelo_services.PrimaryOpenSearch)
 	if err != nil {
 		return nil, err
 	}

--- a/ingestion/mock.go
+++ b/ingestion/mock.go
@@ -86,7 +86,7 @@ func (self *HTTPIngestor) Execute(
 	case "OVERWRITE", "NEW":
 		fmt.Printf("%v: %v\n", plan.Type, plan.DocId)
 
-		client, err := services.GetElasticClient()
+		client, err := services.GetElasticClientByType("primary")
 		if err != nil {
 			return err
 		}

--- a/ingestion/mock.go
+++ b/ingestion/mock.go
@@ -86,7 +86,7 @@ func (self *HTTPIngestor) Execute(
 	case "OVERWRITE", "NEW":
 		fmt.Printf("%v: %v\n", plan.Type, plan.DocId)
 
-		client, err := services.GetElasticClientByType("primary")
+		client, err := services.GetElasticClientByType(services.PrimaryOpenSearch)
 		if err != nil {
 			return err
 		}

--- a/schema/initialize.go
+++ b/schema/initialize.go
@@ -130,14 +130,14 @@ func InstallIndexTemplates(
 		}
 
 		logger.Info("Creating index template %v\n", name)
-		err = services.PutTemplate(ctx, name, string(data), "primary")
+		err = services.PutTemplate(ctx, name, string(data), services.PrimaryOpenSearch)
 		if err != nil {
 			logger := logging.GetLogger(config_obj.VeloConf(), &logging.FrontendComponent)
 			logger.Error("While creating index template %v: %v",
 				name, err)
 		}
 		if config_obj.Cloud.SecondaryAddresses != nil {
-			err = services.PutTemplate(ctx, name, string(data), "secondary")
+			err = services.PutTemplate(ctx, name, string(data), services.SecondaryOpenSearch)
 			if err != nil {
 				logger := logging.GetLogger(config_obj.VeloConf(), &logging.FrontendComponent)
 				logger.Error("While creating index template %v: %v",

--- a/schema/initialize.go
+++ b/schema/initialize.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"www.velocidex.com/golang/cloudvelo/config"
 
 	"github.com/opensearch-project/opensearch-go/v2/opensearchapi"
 	"github.com/pkg/errors"
@@ -32,7 +33,7 @@ var fs embed.FS
 func Delete(ctx context.Context,
 	config_obj *config_proto.Config, org_id, filter string) error {
 
-	client, err := services.GetElasticClient()
+	client, err := services.GetElasticClient(org_id)
 	if err != nil {
 		return err
 	}
@@ -106,13 +107,13 @@ func DeleteAllOrgs(ctx context.Context,
 
 func InstallIndexTemplates(
 	ctx context.Context,
-	config_obj *config_proto.Config) error {
+	config_obj *config.Config) error {
 
 	files, err := fs.ReadDir("templates")
 	if err != nil {
 		return err
 	}
-	logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
+	logger := logging.GetLogger(config_obj.VeloConf(), &logging.FrontendComponent)
 
 	for _, filename := range files {
 		name := strings.Split(filename.Name(), ".")[0]
@@ -129,11 +130,19 @@ func InstallIndexTemplates(
 		}
 
 		logger.Info("Creating index template %v\n", name)
-		err = services.PutTemplate(ctx, name, string(data))
+		err = services.PutTemplate(ctx, name, string(data), "primary")
 		if err != nil {
-			logger := logging.GetLogger(config_obj, &logging.FrontendComponent)
+			logger := logging.GetLogger(config_obj.VeloConf(), &logging.FrontendComponent)
 			logger.Error("While creating index template %v: %v",
 				name, err)
+		}
+		if config_obj.Cloud.SecondaryAddresses != nil {
+			err = services.PutTemplate(ctx, name, string(data), "secondary")
+			if err != nil {
+				logger := logging.GetLogger(config_obj.VeloConf(), &logging.FrontendComponent)
+				logger.Error("While creating index template %v: %v",
+					name, err)
+			}
 		}
 	}
 

--- a/services/elasticsearch.go
+++ b/services/elasticsearch.go
@@ -1022,7 +1022,9 @@ func GetElasticClient(org_id string) (*opensearch.Client, error) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	if primary_orgs[org_id] {
+	// If the config did not specify any primary orgs we always use
+	// the primary client.
+	if len(primary_orgs) == 0 || primary_orgs[org_id] {
 		res, pres := elasticClients[PrimaryOpenSearch]
 		if !pres {
 			return nil, ElasticConfigurationNotInitializedError

--- a/services/elasticsearch.go
+++ b/services/elasticsearch.go
@@ -47,7 +47,8 @@ const (
 
 var (
 	mu             sync.Mutex
-	gElasticClient *opensearch.Client
+	elasticClients map[string]*opensearch.Client
+	primary_orgs   []string
 	TRUE           = true
 	True           = "true"
 
@@ -73,11 +74,19 @@ type IndexInfo struct {
 }
 
 func ListIndexes(ctx context.Context) ([]string, error) {
-	client, err := GetElasticClient()
-	if err != nil {
-		return nil, err
-	}
 
+	results := []string{}
+	for _, client := range elasticClients {
+		indexes, err := listIndexes(client, ctx)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, indexes...)
+	}
+	return results, nil
+}
+
+func listIndexes(client *opensearch.Client, ctx context.Context) ([]string, error) {
 	res, err := opensearchapi.CatIndicesRequest{
 		Format: "json",
 	}.Do(ctx, client)
@@ -103,7 +112,6 @@ func ListIndexes(ctx context.Context) ([]string, error) {
 	}
 
 	return results, nil
-
 }
 
 func GetIndex(org_id, index string) string {
@@ -124,7 +132,7 @@ func DeleteDocument(
 	defer Instrument("DeleteDocument")()
 
 	defer Debug("DeleteDocument %v", id)()
-	client, err := GetElasticClient()
+	client, err := GetElasticClient(org_id)
 	if err != nil {
 		return err
 	}
@@ -153,7 +161,7 @@ func DeleteDocumentByQuery(
 
 	defer Instrument("DeleteDocument")()
 	expanded_index := GetIndex(org_id, index)
-	client, err := GetElasticClient()
+	client, err := GetElasticClient(org_id)
 	if err != nil {
 		return err
 	}
@@ -177,7 +185,7 @@ func DeleteDocumentByQuery(
 // Should be called to force the index to synchronize.
 func FlushIndex(
 	ctx context.Context, org_id, index string) error {
-	client, err := GetElasticClient()
+	client, err := GetElasticClient(org_id)
 	if err != nil {
 		return err
 	}
@@ -206,7 +214,7 @@ func UpdateIndex(
 
 func _UpdateIndex(
 	ctx context.Context, org_id, index, id string, query string) error {
-	client, err := GetElasticClient()
+	client, err := GetElasticClient(org_id)
 	if err != nil {
 		return err
 	}
@@ -238,11 +246,16 @@ func _UpdateIndex(
 }
 
 func DoesTemplateExist(ctx context.Context, name string) error {
-	client, err := GetElasticClient()
-	if err != nil {
-		return err
+	for _, client := range elasticClients {
+		err := doesTemplateExist(client, ctx, name)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
+}
 
+func doesTemplateExist(client *opensearch.Client, ctx context.Context, name string) error {
 	resp, err := opensearchapi.IndicesExistsIndexTemplateRequest{
 		Name: name,
 	}.Do(ctx, client)
@@ -266,11 +279,11 @@ func DoesTemplateExist(ctx context.Context, name string) error {
 }
 
 func PutTemplate(
-	ctx context.Context, name, template string) error {
+	ctx context.Context, name, template string, instance_type string) error {
 
 	defer Instrument("PutTemplate")()
 
-	client, err := GetElasticClient()
+	client, err := GetElasticClientByType(instance_type)
 	if err != nil {
 		return err
 	}
@@ -341,7 +354,7 @@ func SetElasticIndex(ctx context.Context,
 func _SetElasticIndex(
 	ctx context.Context, org_id, index, id string, record interface{}) error {
 	serialized := json.MustMarshalIndent(record)
-	client, err := GetElasticClient()
+	client, err := GetElasticClient(org_id)
 	if err != nil {
 		return err
 	}
@@ -397,6 +410,10 @@ type _AggResults struct {
 	Value   interface{}  `json:"value"`
 }
 
+type _CountResponse struct {
+	Count int `json:"count"`
+}
+
 type _ElasticAgg struct {
 	Results _AggResults `json:"genres"`
 }
@@ -407,17 +424,13 @@ type _ElasticResponse struct {
 	Aggregations _ElasticAgg  `json:"aggregations"`
 }
 
-type _CountResponse struct {
-	Count int `json:"count"`
-}
-
 // Gets a single elastic record by id.
 func GetElasticRecordByQuery(
 	ctx context.Context, org_id, index_suffix, query string) (json.RawMessage, error) {
 	defer Debug("GetElasticRecordByQuery %v %v", index_suffix, query)()
 	defer Instrument("GetElasticRecordByQuery")()
 
-	client, err := GetElasticClient()
+	client, err := GetElasticClient(org_id)
 	if err != nil {
 		return nil, err
 	}
@@ -470,7 +483,7 @@ func GetElasticRecord(
 	defer Debug("GetElasticRecord %v %v", index, id)()
 	defer Instrument("GetElasticRecord")()
 
-	client, err := GetElasticClient()
+	client, err := GetElasticClient(org_id)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +558,7 @@ func GetMultipleElasticRecords(
 		defer Debug("GetMultipleElasticRecords %v %v", index, ids)()
 	}
 
-	client, err := GetElasticClient()
+	client, err := GetElasticClient(org_id)
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +711,7 @@ func DeleteByQuery(
 
 	defer Instrument("DeleteByQuery")()
 
-	client, err := GetElasticClient()
+	client, err := GetElasticClient(org_id)
 	if err != nil {
 		return err
 	}
@@ -732,7 +745,7 @@ func QueryElasticAggregations(
 	defer Instrument("QueryElasticAggregations")()
 	defer Debug("QueryElasticAggregations %v", index)()
 
-	es, err := GetElasticClient()
+	es, err := GetElasticClient(org_id)
 	if err != nil {
 		return nil, err
 	}
@@ -794,7 +807,7 @@ func QueryElasticRaw(
 	defer Instrument("QueryElasticRaw")()
 	defer Debug("QueryElasticRaw %v", index)()
 
-	es, err := GetElasticClient()
+	es, err := GetElasticClient(org_id)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -841,7 +854,7 @@ func QueryElasticIds(
 	org_id, index, query string) (ids []string, total int, err error) {
 
 	defer Instrument("QueryElasticIds")()
-	es, err := GetElasticClient()
+	es, err := GetElasticClient(org_id)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -885,7 +898,7 @@ func QueryCountAPI(
 	org_id, index, query string) (total int, err error) {
 
 	defer Instrument("QueryCountAPI")()
-	es, err := GetElasticClient()
+	es, err := GetElasticClient(org_id)
 	if err != nil {
 		return 0, err
 	}
@@ -930,7 +943,7 @@ func QueryElastic(
 
 	defer Instrument("QueryElastic")()
 
-	es, err := GetElasticClient()
+	es, err := GetElasticClient(org_id)
 	if err != nil {
 		return nil, err
 	}
@@ -972,22 +985,56 @@ func QueryElastic(
 	return results, nil
 }
 
-func GetElasticClient() (*opensearch.Client, error) {
+func GetElasticClientByType(instance_type string) (*opensearch.Client, error) {
 	mu.Lock()
 	defer mu.Unlock()
-
-	if gElasticClient == nil {
-		return nil, errors.New("Elastic configuration not initialized")
+	if instance_type == "primary" {
+		if elasticClients["primary"] == nil {
+			return nil, errors.New("Elastic configuration not initialized")
+		}
+		return elasticClients["primary"], nil
+	} else if instance_type == "secondary" {
+		if elasticClients["secondary"] == nil {
+			return nil, errors.New("Elastic configuration not initialized")
+		}
+		return elasticClients["secondary"], nil
 	}
-
-	return gElasticClient, nil
+	return nil, errors.New("invalid opensearch client instance type")
 }
 
-func SetElasticClient(c *opensearch.Client) {
+func GetElasticClient(org_id string) (*opensearch.Client, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if primary_orgs == nil || arrayContains(primary_orgs, org_id) {
+		if elasticClients["primary"] == nil {
+			return nil, errors.New("Elastic configuration not initialized")
+		}
+		return elasticClients["primary"], nil
+	}
+	if elasticClients["secondary"] == nil {
+		return nil, errors.New("Elastic configuration not initialized")
+	}
+	return elasticClients["secondary"], nil
+}
+
+func arrayContains(a []string, s string) bool {
+	for _, b := range a {
+		if b == s {
+			return true
+		}
+	}
+	return false
+}
+
+func SetElasticClient(clientKey string, c *opensearch.Client) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	gElasticClient = c
+	if elasticClients == nil {
+		elasticClients = map[string]*opensearch.Client{clientKey: c}
+	} else {
+		elasticClients[clientKey] = c
+	}
 }
 
 func SetDebugLogger(config_obj *config_proto.Config) {
@@ -998,19 +1045,44 @@ func SetDebugLogger(config_obj *config_proto.Config) {
 }
 
 func StartElasticSearchService(ctx context.Context, config_obj *cloud_velo_config.Config) error {
-	cfg := opensearch.Config{
+	primary_orgs = config_obj.Cloud.PrimaryOrgs
+	primary_config := opensearch.Config{
 		Addresses: config_obj.Cloud.Addresses,
 	}
 
+	primary_client, err := createOpenSearchClientFromConfig(ctx, config_obj, primary_config)
+	if err != nil {
+		return err
+	}
+
+	// Set the global elastic client
+	SetElasticClient("primary", primary_client)
+
+	// Secondary Clients are only required in environments big enough to required multiple OpenSearch clusters
+	if config_obj.Cloud.SecondaryAddresses != nil {
+		secondary_config := opensearch.Config{
+			Addresses: config_obj.Cloud.SecondaryAddresses,
+		}
+
+		secondary_client, err := createOpenSearchClientFromConfig(ctx, config_obj, secondary_config)
+		if err != nil {
+			return err
+		}
+		SetElasticClient("secondary", secondary_client)
+	}
+	return nil
+}
+
+func createOpenSearchClientFromConfig(ctx context.Context, config_obj *cloud_velo_config.Config, openSearchConfigs opensearch.Config) (*opensearch.Client, error) {
 	CA_Pool := x509.NewCertPool()
 	crypto.AddPublicRoots(CA_Pool)
 
 	if config_obj.Cloud.RootCerts != "" &&
 		!CA_Pool.AppendCertsFromPEM([]byte(config_obj.Cloud.RootCerts)) {
-		return errors.New("cloud ingestion: Unable to add root certs")
+		return nil, errors.New("cloud ingestion: Unable to add root certs")
 	}
 
-	cfg.Transport = &http.Transport{
+	openSearchConfigs.Transport = &http.Transport{
 		MaxIdleConnsPerHost:   10,
 		ResponseHeaderTimeout: 100 * time.Second,
 		TLSClientConfig: &tls.Config{
@@ -1022,35 +1094,33 @@ func StartElasticSearchService(ctx context.Context, config_obj *cloud_velo_confi
 	}
 
 	if config_obj.Cloud.Username != "" && config_obj.Cloud.Password != "" {
-		cfg.Username = config_obj.Cloud.Username
-		cfg.Password = config_obj.Cloud.Password
+		openSearchConfigs.Username = config_obj.Cloud.Username
+		openSearchConfigs.Password = config_obj.Cloud.Password
 	} else {
 		signer_config, err := config.LoadDefaultConfig(ctx)
 		signer, err := requestsigner.NewSigner(signer_config)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		cfg.Signer = signer
+		openSearchConfigs.Signer = signer
 	}
 
-	client, err := opensearch.NewClient(cfg)
+	client, err := opensearch.NewClient(openSearchConfigs)
+
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Fetch info immediately to verify that we can actually connect
 	// to the server.
 	res, err := client.Info()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer res.Body.Close()
 
-	// Set the global elastic client
-	SetElasticClient(client)
-
-	return nil
+	return client, nil
 }
 
 func makeElasticError(data []byte) error {
@@ -1103,11 +1173,11 @@ func MakeId(item string) string {
 
 type BulkIndexer struct {
 	opensearchutil.BulkIndexer
-	ctx        context.Context
-	config_obj *config_proto.Config
-	mu         sync.Mutex
-
-	indexes map[string]bool
+	ctx           context.Context
+	config_obj    *config_proto.Config
+	mu            sync.Mutex
+	instance_type string
+	indexes       map[string]bool
 }
 
 func (self *BulkIndexer) Add(ctx context.Context, item opensearchutil.BulkIndexerItem) error {
@@ -1122,7 +1192,7 @@ func (self *BulkIndexer) Close() error {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
-	elastic_client, err := GetElasticClient()
+	elastic_client, err := GetElasticClientByType(self.instance_type)
 	if err != nil {
 		return err
 	}
@@ -1185,8 +1255,9 @@ func FlushBulkIndexer() error {
 func StartBulkIndexService(
 	ctx context.Context,
 	wg *sync.WaitGroup,
+	instance string,
 	config_obj *cloud_velo_config.Config) error {
-	elastic_client, err := GetElasticClient()
+	elastic_client, err := GetElasticClientByType(instance)
 	if err != nil {
 		return err
 	}
@@ -1215,10 +1286,11 @@ func StartBulkIndexService(
 
 	mu.Lock()
 	bulk_indexer = &BulkIndexer{
-		BulkIndexer: new_bulk_indexer,
-		config_obj:  config_obj.VeloConf(),
-		ctx:         ctx,
-		indexes:     make(map[string]bool),
+		BulkIndexer:   new_bulk_indexer,
+		config_obj:    config_obj.VeloConf(),
+		ctx:           ctx,
+		indexes:       make(map[string]bool),
+		instance_type: instance,
 	}
 	mu.Unlock()
 

--- a/services/orgs/orgs.go
+++ b/services/orgs/orgs.go
@@ -252,14 +252,21 @@ func (self *OrgManager) Start(
 		return err
 	}
 
-	err = cvelo_services.StartBulkIndexService(self.ctx, self.wg, config_obj)
+	err = cvelo_services.StartBulkIndexService(self.ctx, self.wg, "primary", config_obj)
 	if err != nil {
 		return err
 	}
 
+	if config_obj.Cloud.SecondaryAddresses != nil {
+		err = cvelo_services.StartBulkIndexService(self.ctx, self.wg, "secondary", config_obj)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Ensure database is properly initialized
 	// Make sure the database is properly configured
-	err = schema.InstallIndexTemplates(ctx, config_obj.VeloConf())
+	err = schema.InstallIndexTemplates(ctx, config_obj)
 	if err != nil {
 		return err
 	}

--- a/services/orgs/orgs.go
+++ b/services/orgs/orgs.go
@@ -252,13 +252,15 @@ func (self *OrgManager) Start(
 		return err
 	}
 
-	err = cvelo_services.StartBulkIndexService(self.ctx, self.wg, "primary", config_obj)
+	err = cvelo_services.StartBulkIndexService(self.ctx, self.wg,
+		cvelo_services.PrimaryOpenSearch, config_obj)
 	if err != nil {
 		return err
 	}
 
 	if config_obj.Cloud.SecondaryAddresses != nil {
-		err = cvelo_services.StartBulkIndexService(self.ctx, self.wg, "secondary", config_obj)
+		err = cvelo_services.StartBulkIndexService(self.ctx, self.wg,
+			cvelo_services.SecondaryOpenSearch, config_obj)
 		if err != nil {
 			return err
 		}

--- a/testsuite/testsuite.go
+++ b/testsuite/testsuite.go
@@ -97,8 +97,8 @@ func (self *CloudTestSuite) SetupTest() {
 	self.Ctx, self.cancel = context.WithTimeout(context.Background(),
 		time.Second*60)
 
-	config_obj := self.ConfigObj.VeloConf()
-	sm := services.NewServiceManager(self.Ctx, config_obj)
+	config_obj := self.ConfigObj
+	sm := services.NewServiceManager(self.Ctx, config_obj.VeloConf())
 	org_manager, err := orgs.NewOrgManager(sm.Ctx, sm.Wg, self.ConfigObj)
 	assert.NoError(self.T(), err)
 
@@ -108,7 +108,7 @@ func (self *CloudTestSuite) SetupTest() {
 	}
 
 	// Delete the previous indexes for the org.
-	err = schema.Delete(self.Ctx, config_obj, test_org, schema.NO_FILTER)
+	err = schema.Delete(self.Ctx, config_obj.VeloConf(), test_org, schema.NO_FILTER)
 	assert.NoError(self.T(), err)
 
 	_, err = org_manager.CreateNewOrg("test", test_org)


### PR DESCRIPTION
I added the ability to handle a secondary OpenSearch cluster for handling overflow or purposely segmented orgs.