### PR TITLE
Make hunt Expiration Searchable

### DIFF
--- a/services/hunt_dispatcher/create.go
+++ b/services/hunt_dispatcher/create.go
@@ -123,6 +123,7 @@ func (self HuntDispatcher) CreateHunt(
 		"persisted", hunt_id,
 		&HuntEntry{
 			HuntId:    hunt_id,
+			Expires:   hunt.Expires,
 			Timestamp: time.Now().Unix(),
 			Hunt:      string(serialized),
 			State:     hunt.State.String(),

--- a/services/hunt_dispatcher/hunt_dispatcher.go
+++ b/services/hunt_dispatcher/hunt_dispatcher.go
@@ -16,6 +16,7 @@ import (
 type HuntEntry struct {
 	HuntId    string `json:"hunt_id"`
 	Timestamp int64  `json:"timestamp"`
+	Expires   uint64 `json:"expires"`
 	Scheduled uint64 `json:"scheduled"`
 	Completed uint64 `json:"completed"`
 	Errors    uint64 `json:"errors"`


### PR DESCRIPTION
Exposing the hunt expiration time on the elastic record to allow for it to be searchable.