### PR TITLE
Correct type used in event queries

### DIFF
--- a/services/client_monitoring/events.go
+++ b/services/client_monitoring/events.go
@@ -86,7 +86,7 @@ func listAvailableEventArtifacts(
 		// artifacts runner, it is still possible for server artifacts
 		// to be written by various services (e.g. Audit manager).
 		query = json.Format(getAvailableServerArtifactsQuery,
-			"server", "transient", OPENSEARCH_MAX_BUCKETS)
+			"server", "results", OPENSEARCH_MAX_BUCKETS)
 
 	} else {
 		// Even if client events are not generated there are always
@@ -175,7 +175,7 @@ func listAvailableEventTimestamps(
 
 	} else {
 		query = json.Format(getAvailableEventTimesQuery, in.ClientId,
-			"transient", in.Artifact, OPENSEARCH_MAX_BUCKETS)
+			"results", in.Artifact, OPENSEARCH_MAX_BUCKETS)
 	}
 
 	hits, err := cvelo_services.QueryElasticAggregations(ctx,


### PR DESCRIPTION
`Viewing Server Audit Log` was broken in the migration to `persisted` and `transient` index names,
PR corrects the `type` field used in queries to correctly retrieve monitoring events