### PR TITLE
Fix starting paused Hunts setting expires & timestamp to 0

### DIFF
--- a/services/hunt_dispatcher/hunt_dispatcher.go
+++ b/services/hunt_dispatcher/hunt_dispatcher.go
@@ -130,11 +130,12 @@ func (self HuntDispatcher) SetHunt(hunt *api_proto.Hunt) error {
 	}
 
 	record := &HuntEntry{
-		HuntId:  hunt_id,
-		Expires: hunt.Expires,
-		Hunt:    string(serialized),
-		State:   hunt.State.String(),
-		DocType: "hunts",
+		HuntId:    hunt_id,
+		Timestamp: int64(hunt.CreateTime / 1000000),
+		Expires:   hunt.Expires,
+		Hunt:      string(serialized),
+		State:     hunt.State.String(),
+		DocType:   "hunts",
 	}
 
 	if hunt.Stats != nil {

--- a/services/hunt_dispatcher/hunt_dispatcher.go
+++ b/services/hunt_dispatcher/hunt_dispatcher.go
@@ -131,6 +131,7 @@ func (self HuntDispatcher) SetHunt(hunt *api_proto.Hunt) error {
 
 	record := &HuntEntry{
 		HuntId:  hunt_id,
+		Expires: hunt.Expires,
 		Hunt:    string(serialized),
 		State:   hunt.State.String(),
 		DocType: "hunts",


### PR DESCRIPTION
Fixes issues where users were starting paused Hunts and having them immediately stopped due to `expires` being set to 0 when updating the OpenSearch document to change the hunt status.

`timestamp` was also being set to 0, included a fix to prevent this as well.  