### PR TITLE
Fix labels to Hunt against only returning 10 options

### DIFF
--- a/services/indexing/search.go
+++ b/services/indexing/search.go
@@ -147,7 +147,7 @@ const (
  "query": {"prefix": {%q: {"value": %q,  "case_insensitive": true}}},
  "aggs": {
     "genres": {
-      "terms": { "field": %q }
+      "terms": { "field": %q , "size": 100}
     }
   },
  "fields": [ "client_id" ],


### PR DESCRIPTION
There was a bug in retrieving the labels added to a client and selecting the labels to apply a Hunt to, the maximum returned values was 10 (the OpenSearch default).

Decided to set the query response limit to 100 to match the limit used by the UI when sending requests to the server for retrieving the labels for a client & Hunt